### PR TITLE
[E46 M3] Optimize AFR, Steering Angle and Interior Night Lighting Parameters

### DIFF
--- a/definitions/M3_E46.json
+++ b/definitions/M3_E46.json
@@ -308,34 +308,22 @@
 			"noLog": false
 		},
 		{
-			"header": "Steering Angle Raw",
+			"header": "Steering Angle",
+			"unit": "deg",
 			"canId": "0x1F5",
 			"offset": 0,
 			"length": 2,
-			"hidden": false,
-			"noLog": true
-		},
-		{
-			"header": "Steering Angle",
-			"unit": "deg",
 			"expr": "(x > 32768)*((x-32768)*.044) + (x<32768)*(-.044*x)",
-			"x": "Steering Angle Raw",
 			"hidden": false,
-			"noLog": true
+			"noLog": false
 		},
 		{
 			// Reference: https://www.ms4x.net/index.php?title=CAN_Bus_ID_0x615_ICL3
-			"header": "Instrument Cluster ICL3 Byte 1 Raw",
+			"header": "Interior Night Lighting",
+			"unit": "bool",
 			"canId": "0x615",
 			"offset": 1,
 			"length": 1,
-			"hidden": true,
-			"noLog": true
-		},
-		{
-			"header": "Interior Night Lighting",
-			"unit": "bool",
-			"x": "Instrument Cluster ICL3 Byte 1 Raw",
 			// Bit 2: Interior Night Lighting - 0 off, 1 on
 			"expr": "(x & 4) >> 2",
 			"hidden": true,

--- a/definitions/M3_E46_Extra.json
+++ b/definitions/M3_E46_Extra.json
@@ -38,22 +38,17 @@
     //  |    |7 (msb)|128    |Reserved             |               |                   |      |                   |
     //  '----+-------+-------+---------------------+---------------+-------------------+------+-------------------'
     {
-      "header": "CAN Lambda Big Endian",
-      "canId": "0x180",
-      "offset": 0,
-      "length": 2,
-      "hidden": true,
-      "noLog": true
-    },
-    {
-      "header": "AFR",
-      "expr": "(((x & 255) << 8) | ((x & 65280) >> 8)) * 0.00147", // Convert to little-endian and then from lambda to AFR. Resolution is .0001 Lambda/bit, stoichiometric ratio used is 14.7
-      "x": "CAN Lambda Big Endian",
-      "dec": 1,
-      "max": 22,
-      "min": 7,
-      "hidden": true, // CAN AFR parameter is turned off by default, set `hidden` and `noLog` to true if in use.
-      "noLog": true
-    },
+			"header": "AFR",
+			"canId": "0x180",
+			"offset": 0,
+			"length": 2,
+			"reverseEndianness": true,
+			"expr": "x * 0.00147", // Resolution is .0001 Lambda/bit, stoichiometric ratio used is 14.7
+			"dec": 1,
+			"max": 22,
+			"min": 7,
+			"hidden": false,
+			"noLog": false
+		}
   ]
 }


### PR DESCRIPTION
This change saves storing three parameters by consolidating the raw values into the parameters themselves.